### PR TITLE
Added support for named arguments in ICU translations.

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/types/CheckContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/types/CheckContext.kt
@@ -153,8 +153,30 @@ public open class CheckContext<out T : Event>(public val event: T, public val lo
     /** Quick access to translate strings using this check context's [locale]. **/
     public fun translate(
         key: String,
-        bundle: String? = defaultBundle,
+        bundle: String?,
         replacements: Array<Any?> = arrayOf()
+    ): String =
+        translations.translate(key, locale, bundleName = bundle, replacements = replacements)
+
+    /** Quick access to translate strings using this check context's [locale]. **/
+    public fun translate(
+        key: String,
+        replacements: Array<Any?> = arrayOf()
+    ): String =
+        translations.translate(key, locale, bundleName = defaultBundle, replacements = replacements)
+
+    /** Quick access to translate strings using this check context's [locale]. **/
+    public fun translate(
+        key: String,
+        replacements: Map<String, Any?>
+    ): String =
+        translations.translate(key, locale, bundleName = defaultBundle, replacements = replacements)
+
+    /** Quick access to translate strings using this check context's [locale]. **/
+    public fun translate(
+        key: String,
+        bundle: String?,
+        replacements: Map<String, Any?>
     ): String =
         translations.translate(key, locale, bundleName = bundle, replacements = replacements)
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
@@ -106,10 +106,34 @@ public abstract class CommandContext(
     }
 
     /**
+     * Given a translation key and bundle name, return the translation for the locale provided by the bot's configured
+     * locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale = getLocale()
+
+        return translationsProvider.translate(key, locale, bundleName, replacements)
+    }
+
+    /**
      * Given a translation key and possible replacements,return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(
+        key,
+        command.resolvedBundle,
+        replacements
+    )
+
+    /**
+     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun translate(key: String, replacements: Map<String, Any?>): String = translate(
         key,
         command.resolvedBundle,
         replacements

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventContext.kt
@@ -47,21 +47,25 @@ public open class EventContext<T : Event>(
         bundleName: String?,
         replacements: Array<Any?> = arrayOf()
     ): String {
-        val eventObj = event as Event
-        var locale: Locale? = null
+        val locale: Locale? = resolveLocale()
 
-        val guild = guildFor(eventObj)
-        val channel = channelFor(eventObj)
-        val user = userFor(eventObj)
-
-        for (resolver in eventHandler.extension.bot.settings.i18nBuilder.localeResolvers) {
-            val result = resolver(guild, channel, user, interactionFor(eventObj))
-
-            if (result != null) {
-                locale = result
-                break
-            }
+        return if (locale != null) {
+            translationsProvider.translate(key, locale, bundleName, replacements)
+        } else {
+            translationsProvider.translate(key, bundleName, replacements)
         }
+    }
+
+    /**
+     * Given a translation key and optional bundle name, return the translation for the locale provided by the bot's
+     * configured locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale: Locale? = resolveLocale()
 
         return if (locale != null) {
             translationsProvider.translate(key, locale, bundleName, replacements)
@@ -78,4 +82,30 @@ public open class EventContext<T : Event>(
         key: String,
         replacements: Array<Any?> = arrayOf()
     ): String = translate(key, eventHandler.extension.bundle, replacements)
+
+    /**
+     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        replacements: Map<String, Any?>
+    ): String = translate(key, eventHandler.extension.bundle, replacements)
+
+    private suspend fun resolveLocale(): Locale? {
+        val eventObj = event as Event
+
+        val guild = guildFor(eventObj)
+        val channel = channelFor(eventObj)
+        val user = userFor(eventObj)
+
+        for (resolver in eventHandler.extension.bot.settings.i18nBuilder.localeResolvers) {
+            val result = resolver(guild, channel, user, interactionFor(eventObj))
+
+            if (result != null) {
+                return result
+            }
+        }
+        return null
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -270,10 +270,34 @@ public open class EventHandler<T : Event>(
     }
 
     /**
+     * Given a translation key and bundle name, return the translation for the locale provided by the bot's configured
+     * locale resolvers.
+     */
+    public suspend fun Event.translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale = getLocale()
+
+        return translationsProvider.translate(key, locale, bundleName, replacements)
+    }
+
+    /**
      * Given a translation key and possible replacements,return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun Event.translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(
+        key,
+        extension.bundle,
+        replacements
+    )
+
+    /**
+     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun Event.translate(key: String, replacements: Map<String, Any?>): String = translate(
         key,
         extension.bundle,
         replacements

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/ResourceBundleTranslations.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/ResourceBundleTranslations.kt
@@ -120,7 +120,7 @@ public open class ResourceBundleTranslations(
         return result
     }
 
-    override fun translate(key: String, locale: Locale, bundleName: String?, replacements: Array<Any?>): String {
+    private fun getTranslatedString(key: String, locale: Locale, bundleName: String?): String {
         var string = try {
             get(key, locale, bundleName)
         } catch (e: MissingResourceException) {
@@ -134,10 +134,7 @@ public open class ResourceBundleTranslations(
 
                 string = get(key, locale, KORDEX_KEY)
             }
-
-            val formatter = MessageFormat(string, locale)
-
-            formatter.format(replacements)
+            string
         } catch (e: MissingResourceException) {
             logger.trace {
                 if (bundleName == null) {
@@ -149,6 +146,22 @@ public open class ResourceBundleTranslations(
 
             key
         }
+    }
+
+    override fun translate(key: String, locale: Locale, bundleName: String?, replacements: Array<Any?>): String {
+        val string = getTranslatedString(key, locale, bundleName)
+
+        val formatter = MessageFormat(string, locale)
+
+        return formatter.format(replacements)
+    }
+
+    override fun translate(key: String, locale: Locale, bundleName: String?, replacements: Map<String, Any?>): String {
+        val string = getTranslatedString(key, locale, bundleName)
+
+        val formatter = MessageFormat(string, locale)
+
+        return formatter.format(replacements)
     }
 
     private fun ResourceBundle.getStringOrNull(key: String): String? {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/TranslationsProvider.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/TranslationsProvider.kt
@@ -115,4 +115,44 @@ public abstract class TranslationsProvider(
         bundleName: String? = null,
         replacements: List<Any?>
     ): String = translate(key, language, country, bundleName, replacements.toTypedArray())
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String = translate(key, defaultLocale, bundleName, replacements)
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        bundleName: String? = null,
+        locale: Locale,
+        replacements: Map<String, Any?>
+    ): String = translate(key, locale, bundleName, replacements)
+
+    /** Get a formatted translation using the provided arguments. **/
+    public abstract fun translate(
+        key: String,
+        locale: Locale,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        language: String,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String = translate(key, Locale(language), bundleName, replacements)
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        language: String,
+        country: String,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String = translate(key, Locale(language, country), bundleName, replacements)
 }

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
@@ -11,6 +11,7 @@ package com.kotlindiscord.kord.extensions.testbot.extensions
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.group
 import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
+import com.kotlindiscord.kord.extensions.commands.converters.impl.int
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
@@ -94,6 +95,23 @@ public class I18nTestExtension : Extension() {
                 }
             }
         }
+
+        publicSlashCommand(::I18nTestNamedArguments) {
+            name = "command.apple"
+            description = "command.apple"
+
+            action {
+                respond {
+                    content = translate(
+                        "command.apple.response",
+                        mapOf(
+                            "name" to arguments.name,
+                            "appleCount" to arguments.count
+                        )
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -106,5 +124,17 @@ internal class I18nTestArguments : Arguments() {
                 listOf("Banana", "Apple", "Cherry").forEach { choice(it, it) }
             }
         }
+    }
+}
+
+internal class I18nTestNamedArguments : Arguments() {
+    val name by string {
+        name = "command.apple.argument.name"
+        description = "command.apple.argument.name"
+    }
+
+    val count by int {
+        name = "command.apple.argument.count"
+        description = "command.apple.argument.count"
     }
 }

--- a/test-bot/src/main/resources/translations/test/strings.properties
+++ b/test-bot/src/main/resources/translations/test/strings.properties
@@ -10,3 +10,7 @@ command.banana-sub=banana-sub
 command.banana-group=banana-group
 command.fruit=fruit
 command.fruit.response=my favorite fruit is {0}
+command.apple=apple
+command.apple.response=Hello my name is **{name}** and I have **{appleCount, number}** {appleCount, plural, =1{apple} other {apples}}.
+command.apple.argument.name=name
+command.apple.argument.count=apple_count


### PR DESCRIPTION
This adds overloads to all translate functions to also accept a mapping of argument names to argument values:

**Example**:
```
command.apple.response=Hello my name is **{name}** and I have **{appleCount, number}** {appleCount, plural, =1{apple} other {apples}}.
```

```kt
translate("command.apple.response", mapOf("name" to "Allan", "appleCount" to 120))
> Hello my name is **Allan** and I have **1** apple.
```

In some cases I extracted some code out current `translate` methods to avoid repeating it for the overload for named arguments.



